### PR TITLE
Disambiguate keys of serilog:using XML configuration directives

### DIFF
--- a/SerilogAnalyzer/SerilogAnalyzer.Test/RefactoringTests.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer.Test/RefactoringTests.cs
@@ -153,7 +153,7 @@ class TypeName
     {
         /*
         <add key=""serilog:write-to:LiterateConsole.restrictedToMinimumLevel"" value=""Verbose"" />
-        <add key=""serilog:using"" value=""Serilog.Sinks.Literate"" />
+        <add key=""serilog:using:Literate"" value=""Serilog.Sinks.Literate"" />
         */
         ILogger test = new LoggerConfiguration()
             .WriteTo.LiterateConsole(Serilog.Events.LogEventLevel.Verbose)
@@ -193,7 +193,7 @@ class TypeName
         <add key=""serilog:enrich:with-property:AppName"" value=""test"" />
         <add key=""serilog:write-to:LiterateConsole.outputTemplate"" value=""test"" />
         <add key=""serilog:write-to:LiterateConsole.restrictedToMinimumLevel"" value=""Information"" />
-        <add key=""serilog:using"" value=""Serilog.Sinks.Literate"" />
+        <add key=""serilog:using:Literate"" value=""Serilog.Sinks.Literate"" />
         */
         ILogger test = new LoggerConfiguration()
             .Enrich.WithProperty(""AppName"", ""test"")
@@ -403,7 +403,7 @@ class TypeName
         /*
         <add key=""serilog:write-to:RollingFile.pathFormat"" value=""logfile.txt"" />
         <add key=""serilog:write-to:RollingFile.retainedFileCountLimit"" />
-        <add key=""serilog:using"" value=""Serilog.Sinks.RollingFile"" />
+        <add key=""serilog:using:RollingFile"" value=""Serilog.Sinks.RollingFile"" />
         */
         ILogger test = new LoggerConfiguration()
             .WriteTo.RollingFile(""logfile.txt"" retainedFileCountLimit: null)

--- a/SerilogAnalyzer/SerilogAnalyzer/CodeRefactoringProvider.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer/CodeRefactoringProvider.cs
@@ -323,11 +323,17 @@ namespace SerilogAnalyzer
                 ConvertExtensibleMethod(configEntries, writeTo, "serilog:write-to");
             }
 
+            var usedSuffixes = new HashSet<string>();
             foreach (var usedAssembly in configuration.Enrich.Concat(configuration.WriteTo).Select(x => x.AssemblyName).Distinct())
             {
                 if (usedAssembly != "Serilog")
                 {
-                    AddEntry(configEntries, "serilog:using", usedAssembly);
+                    var parts = usedAssembly.Split('.');
+                    var suffix = parts.Last();
+                    if (usedSuffixes.Contains(suffix))
+                        suffix = string.Join("", parts);
+
+                    AddEntry(configEntries, $"serilog:using:{suffix}", usedAssembly);
                 }
             }
 


### PR DESCRIPTION
Keys in `<add key="serilog:using"...` statements must be unique.

This PR uses the referenced assembly name to generate keys like: `<add key="serilog:using:RollingFile"`.

![image](https://cloud.githubusercontent.com/assets/342712/18652829/e3f4f430-7f18-11e6-81f2-124034c520c1.png)
