### PR TITLE
Adds support for .AuditTo configurations

### DIFF
--- a/SerilogAnalyzer/SerilogAnalyzer.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -40,6 +40,7 @@ namespace TestHelper
         private static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
         private static readonly MetadataReference SerilogReference = MetadataReference.CreateFromFile(typeof(ILogger).Assembly.Location);
         private static readonly MetadataReference SerilogLiterateReference = MetadataReference.CreateFromFile(typeof(LoggerConfigurationLiterateExtensions).Assembly.Location);
+        private static readonly MetadataReference SerilogFileReference = MetadataReference.CreateFromFile(typeof(FileLoggerConfigurationExtensions).Assembly.Location);
         private static readonly MetadataReference SerilogRollingFileReference = MetadataReference.CreateFromFile(typeof(RollingFileLoggerConfigurationExtensions).Assembly.Location);
 
         internal static string DefaultFilePathPrefix = "Test";
@@ -203,6 +204,7 @@ namespace TestHelper
                 .AddMetadataReference(projectId, CodeAnalysisReference)
                 .AddMetadataReference(projectId, SerilogReference)
                 .AddMetadataReference(projectId, SerilogLiterateReference)
+                .AddMetadataReference(projectId, SerilogFileReference)
                 .AddMetadataReference(projectId, SerilogRollingFileReference);
 
             int count = 0;

--- a/SerilogAnalyzer/SerilogAnalyzer/CodeRefactoringProvider.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer/CodeRefactoringProvider.cs
@@ -18,7 +18,7 @@ namespace SerilogAnalyzer
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = nameof(SerilogAnalyzerCodeRefactoringProvider)), Shared]
     public class SerilogAnalyzerCodeRefactoringProvider : CodeRefactoringProvider
     {
-        private static string[] InterestingProperties = { "Destructure", "Enrich", "Filter", "MinimumLevel", "ReadFrom", "WriteTo" };
+        private static string[] InterestingProperties = { "Destructure", "Enrich", "Filter", "MinimumLevel", "ReadFrom", "WriteTo", "AuditTo" };
         private static string[] LogLevels = { "Debug", "Error", "Fatal", "Information", "Verbose", "Warning" };
 
         public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
@@ -46,17 +46,19 @@ namespace SerilogAnalyzer
             }
 
             LoggerConfiguration configuration = GetLoggerConfigurationFromSyntax(context, semanticModel, configurationProperties);
-            if (configuration.Enrich.Count == 0 && configuration.EnrichWithProperty.Count == 0 && configuration.MinimumLevel == null && configuration.MinimumLevelOverrides.Count == 0 && configuration.WriteTo.Count == 0)
-            {
-                return;
-            }
 
-            if (configuration.Enrich.Count > 0 || configuration.EnrichWithProperty.Count > 0 || configuration.MinimumLevel != null || configuration.WriteTo.Count > 0)
+            var appSettingsApplicable = configuration.Enrich.Count > 0 || configuration.EnrichWithProperty.Count > 0 ||
+                                        configuration.MinimumLevel != null || configuration.WriteTo.Count > 0 || configuration.AuditTo.Count > 0;
+
+            if (appSettingsApplicable)
             {
                 context.RegisterRefactoring(CodeAction.Create("Show <appSettings> config", c => InsertConfigurationComment(context.Document, firstProperty, root, configuration, GetAppSettingsConfiguration, c)));
             }
 
-            context.RegisterRefactoring(CodeAction.Create("Show appsettings.json config", c => InsertConfigurationComment(context.Document, firstProperty, root, configuration, GetAppSettingsJsonConfiguration, c)));
+            if (appSettingsApplicable || configuration.MinimumLevelOverrides.Count > 0)
+            {
+                context.RegisterRefactoring(CodeAction.Create("Show appsettings.json config", c => InsertConfigurationComment(context.Document, firstProperty, root, configuration, GetAppSettingsJsonConfiguration, c)));
+            }
         }
 
         private static LoggerConfiguration GetLoggerConfigurationFromSyntax(CodeRefactoringContext context, SemanticModel semanticModel, List<MemberAccessExpressionSyntax> configurationProperties)
@@ -209,6 +211,14 @@ namespace SerilogAnalyzer
                         configuration.WriteTo.Add(method);
                     }
                 }
+                else if (configAction == "AuditTo")
+                {
+                    var method = GetExtensibleMethod(semanticModel, invokedMethod, context.CancellationToken);
+                    if (method != null)
+                    {
+                        configuration.AuditTo.Add(method);
+                    }
+                }
             }
 
             return configuration;
@@ -323,8 +333,13 @@ namespace SerilogAnalyzer
                 ConvertExtensibleMethod(configEntries, writeTo, "serilog:write-to");
             }
 
+            foreach (var auditTo in configuration.AuditTo)
+            {
+                ConvertExtensibleMethod(configEntries, auditTo, "serilog:audit-to");
+            }
+
             var usedSuffixes = new HashSet<string>();
-            foreach (var usedAssembly in configuration.Enrich.Concat(configuration.WriteTo).Select(x => x.AssemblyName).Distinct())
+            foreach (var usedAssembly in configuration.Enrich.Concat(configuration.WriteTo).Concat(configuration.AuditTo).Select(x => x.AssemblyName).Distinct())
             {
                 if (usedAssembly != "Serilog")
                 {
@@ -384,7 +399,7 @@ namespace SerilogAnalyzer
             bool needsComma = false;
 
             // technically it's not correct to abuse roslyn to escape the string literals for us but csharp strings look very much like js string literals so...
-            string usings = String.Join(", ", configuration.Enrich.Concat(configuration.WriteTo).Select(x => x.AssemblyName).Distinct().Select(x => SyntaxFactory.Literal(x).ToString()));
+            string usings = String.Join(", ", configuration.Enrich.Concat(configuration.WriteTo).Concat(configuration.AuditTo).Select(x => x.AssemblyName).Distinct().Select(x => SyntaxFactory.Literal(x).ToString()));
             if (!String.IsNullOrEmpty(usings))
             {
                 sb.AppendFormat(@"  ""Using"": [{0}]", usings);
@@ -434,6 +449,14 @@ namespace SerilogAnalyzer
             {
                 FinishPreviousLine(sb, ref needsComma);
                 WriteMethodCalls(configuration.WriteTo, sb, "WriteTo");
+
+                needsComma = true;
+            }
+
+            if (configuration.AuditTo.Any())
+            {
+                FinishPreviousLine(sb, ref needsComma);
+                WriteMethodCalls(configuration.AuditTo, sb, "AuditTo");
 
                 needsComma = true;
             }

--- a/SerilogAnalyzer/SerilogAnalyzer/ConfigurationModel.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer/ConfigurationModel.cs
@@ -7,6 +7,7 @@ namespace SerilogAnalyzer
         public string MinimumLevel { get; set; }
         public Dictionary<string, string> MinimumLevelOverrides { get; set; } = new Dictionary<string, string>();
         public List<ExtensibleMethod> WriteTo { get; set; } = new List<ExtensibleMethod>();
+        public List<ExtensibleMethod> AuditTo { get; set; } = new List<ExtensibleMethod>();
         public List<ExtensibleMethod> Enrich { get; set; } = new List<ExtensibleMethod>();
         public Dictionary<string, string> EnrichWithProperty { get; set; } = new Dictionary<string, string>();
     }


### PR DESCRIPTION
As per:

```csharp
        /*
        <add key="serilog:audit-to:File.path" value="C:\Path\Filename" />
        <add key="serilog:using:File" value="Serilog.Sinks.File" />
        */
        ILogger test = new LoggerConfiguration()
            .AuditTo.File("C:\\Path\\Filename")
            .CreateLogger();
```

and the JSON equivalent.