### PR TITLE
Fix for issue 19: not recognising params object[] in custom abstraction

### DIFF
--- a/SerilogAnalyzer/SerilogAnalyzer.Test/AnalyzerTests.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer.Test/AnalyzerTests.cs
@@ -810,7 +810,7 @@ class Program
             public static void Test()
             {
                 int id = 1;
-                IMyLogger log;
+                IMyLogger log = null;
                 log.Error(""The id is {Id}"", id);
             }
         }

--- a/SerilogAnalyzer/SerilogAnalyzer.Test/AnalyzerTests.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer.Test/AnalyzerTests.cs
@@ -783,6 +783,41 @@ class Program
             VerifyCSharpDiagnostic(src, expected);
         }
 
+        [TestMethod]
+        public void TestIssue19()
+        {
+            var test = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+    using Serilog.Core;
+
+    namespace ConsoleApplication1
+    {
+        public interface IMyLogger
+        {
+            [MessageTemplateFormatMethod(""messageTemplate"")]
+            void Error(string messageTemplate, params object[] values);
+            [MessageTemplateFormatMethod(""messageTemplate"")]
+            void Error(Exception exception, string messageTemplate, params object[] values);
+        }
+
+        class TypeName
+        {
+            public static void Test()
+            {
+                int id = 1;
+                IMyLogger log;
+                log.Error(""The id is {Id}"", id);
+            }
+        }
+    }";
+            VerifyCSharpDiagnostic(test);
+        }
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new SerilogAnalyzerCodeFixProvider();

--- a/SerilogAnalyzer/SerilogAnalyzer/DiagnosticAnalyzer.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer/DiagnosticAnalyzer.cs
@@ -101,8 +101,8 @@ namespace SerilogAnalyzer
             var stringText = default(string);
             foreach (var argument in invocation.ArgumentList.Arguments)
             {
-                var paramter = RoslynHelper.DetermineParameter(argument, context.SemanticModel, true, context.CancellationToken);
-                if (paramter.Name == messageTemplateName)
+                var parameter = RoslynHelper.DetermineParameter(argument, context.SemanticModel, true, context.CancellationToken);
+                if (parameter.Name == messageTemplateName)
                 {
                     string messageTemplate;
 
@@ -150,7 +150,7 @@ namespace SerilogAnalyzer
                         }
                     }
                 }
-                else if (paramter.Name.StartsWith("propertyValue", StringComparison.Ordinal))
+                else if (parameter.Name.StartsWith("propertyValue", StringComparison.Ordinal))
                 {
                     var location = argument.GetLocation().SourceSpan;
                     arguments.Add(new SourceArgument { StartIndex = location.Start, Length = location.Length });

--- a/SerilogAnalyzer/SerilogAnalyzer/DiagnosticAnalyzer.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer/DiagnosticAnalyzer.cs
@@ -155,10 +155,9 @@ namespace SerilogAnalyzer
                     var location = argument.GetLocation().SourceSpan;
                     arguments.Add(new SourceArgument { StartIndex = location.Start, Length = location.Length });
                 }
-                // TODO: also verify that the array type is object[]
-                else if (parameter.IsParams && parameter.Type.Kind == SymbolKind.ArrayType )
+                else if (parameter.IsParams && parameter.Type.Kind == SymbolKind.ArrayType &&
+                    ((IArrayTypeSymbol)parameter.Type).ElementType.MetadataName == "Object")
                 {
-                    // TODO: add all remaining arguments, instead of only the current one, and shortcircuit the loop
                     var location = argument.GetLocation().SourceSpan;
                     arguments.Add(new SourceArgument { StartIndex = location.Start, Length = location.Length });
                 }

--- a/SerilogAnalyzer/SerilogAnalyzer/DiagnosticAnalyzer.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer/DiagnosticAnalyzer.cs
@@ -155,6 +155,13 @@ namespace SerilogAnalyzer
                     var location = argument.GetLocation().SourceSpan;
                     arguments.Add(new SourceArgument { StartIndex = location.Start, Length = location.Length });
                 }
+                // TODO: also verify that the array type is object[]
+                else if (parameter.IsParams && parameter.Type.Kind == SymbolKind.ArrayType )
+                {
+                    // TODO: add all remaining arguments, instead of only the current one, and shortcircuit the loop
+                    var location = argument.GetLocation().SourceSpan;
+                    arguments.Add(new SourceArgument { StartIndex = location.Start, Length = location.Length });
+                }
             }
 
             // do properties match up?

--- a/SerilogAnalyzer/SerilogAnalyzer/DiagnosticAnalyzer.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer/DiagnosticAnalyzer.cs
@@ -155,8 +155,7 @@ namespace SerilogAnalyzer
                     var location = argument.GetLocation().SourceSpan;
                     arguments.Add(new SourceArgument { StartIndex = location.Start, Length = location.Length });
                 }
-                else if (parameter.IsParams && parameter.Type.Kind == SymbolKind.ArrayType &&
-                    ((IArrayTypeSymbol)parameter.Type).ElementType.MetadataName == "Object")
+                else if (parameter.IsParams && IsObjectArray(parameter))
                 {
                     var location = argument.GetLocation().SourceSpan;
                     arguments.Add(new SourceArgument { StartIndex = location.Start, Length = location.Length });
@@ -205,6 +204,21 @@ namespace SerilogAnalyzer
                     context.ReportDiagnostic(Diagnostic.Create(ExceptionRule, argument.GetLocation(), argument.Expression.ToFullString()));
                 }
             }
+        }
+
+        private static bool IsObjectArray(IParameterSymbol parameter)
+        {
+            var arrayTypeSymbol = parameter.Type as IArrayTypeSymbol;
+            if (arrayTypeSymbol == null)
+            {
+                return false;
+            }
+
+            var symbolDisplayFormat = new SymbolDisplayFormat(
+                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
+
+            string fullyQualifiedName = arrayTypeSymbol.ElementType.ToDisplayString(symbolDisplayFormat);
+            return fullyQualifiedName == "System.Object";
         }
 
         private static void ReportDiagnostic(ref SyntaxNodeAnalysisContext context, ref TextSpan literalSpan, string stringText, bool exactPositions, DiagnosticDescriptor rule, MessageTemplateDiagnostic diagnostic)


### PR DESCRIPTION
As discussed a PR to fix #19 for me. This recognises `params object[]` parameters in a call to the logger, and takes that into account.

A couple things to note:

 * I put in an unit test for specifically reproducing this scenario. I first tried to reproduce it on the Serilog logger, however, I found out that it doesn't fail there, since the [`params object[]`](https://github.com/serilog/serilog/blob/dev/src/Serilog/ILogger.cs#L485) also starts with ["propertyValue"](https://github.com/serilog/serilog/blob/dev/src/Serilog/ILogger.cs#L485) (**so it actually works correctly for Serilog**!). This way I was able to reproduce it for me.

 * I thought there was an easy check, or extension method for checking on `params object[]` parameters, but I couldn't find it. I did find this [SO](http://stackoverflow.com/a/23314956/471780) answer for verifying the type, but I'm not 100% sure if this is the right approach. We can also just go with `parameter.IsParams && parameter.Type.Kind == SymbolKind.ArrayType`, or even just `parameter.IsParams`.