### PR TITLE
Adding Pascal Case Support

### DIFF
--- a/SerilogAnalyzer/SerilogAnalyzer.Test/AnalyzerTests.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer.Test/AnalyzerTests.cs
@@ -784,6 +784,24 @@ class Program
         }
 
         [TestMethod]
+        public void TestPascalCaseFormattingRule()
+        {
+            string src = GetTemplateTestSource("{tester} chats with himself", "tester1");
+
+            var expected = new DiagnosticResult
+            {
+                Id = "Serilog006",
+                Message = String.Format("Property name '{0}' should be pascal case", "tester"),
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 7, 27)
+                }
+            };
+            VerifyCSharpDiagnostic(src, expected);
+        }
+
+        [TestMethod]
         public void TestIssue19()
         {
             var test = @"

--- a/SerilogAnalyzer/SerilogAnalyzer.Test/PascalCaseAnalyzerTests.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer.Test/PascalCaseAnalyzerTests.cs
@@ -1,0 +1,186 @@
+﻿// Copyright 2017 Serilog Analyzer Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using TestHelper;
+
+namespace SerilogAnalyzer.Test
+{
+    [TestClass]
+    public class PascalCaseAnalyzerTests : CodeFixVerifier
+    {
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new SerilogAnalyzerPascalCaseCodeFixProvider();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new SerilogAnalyzerAnalyzer();
+        }
+
+        [TestMethod]
+        public void TestPascalCaseFixForString()
+        {
+            string src = @"
+using Serilog;
+
+class TypeName
+{
+    public static void Test()
+    {
+        var foo = ""tester"";
+        Log.Verbose(""Hello {tester}"", foo));
+    }
+}";
+            var expected = new DiagnosticResult
+            {
+                Id = "Serilog006",
+                Message = String.Format("Property name '{0}' should be pascal case", "tester"),
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 9, 28, 8)
+                }
+            };
+            VerifyCSharpDiagnostic(src, expected);
+
+            var fixtest = @"
+using Serilog;
+
+class TypeName
+{
+    public static void Test()
+    {
+        var foo = ""tester"";
+        Log.Verbose(""Hello {Tester}"", foo));
+    }
+}";
+            VerifyCSharpFix(src, fixtest);
+        }
+
+        [TestMethod]
+        public void TestPascalCaseFixForObject()
+        {
+            string src = @"
+using Serilog;
+
+class TypeName
+{
+    public static void Test()
+    {
+        var foo = ""tester"";
+        Log.Verbose(""Hello {@tester}"", foo));
+    }
+}";
+            var expected = new DiagnosticResult
+            {
+                Id = "Serilog006",
+                Message = $"Property name '{"tester"}' should be pascal case",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 9, 28, 9)
+                }
+            };
+            VerifyCSharpDiagnostic(src, expected);
+
+            var fixtest = @"
+using Serilog;
+
+class TypeName
+{
+    public static void Test()
+    {
+        var foo = ""tester"";
+        Log.Verbose(""Hello {@Tester}"", foo));
+    }
+}";
+            VerifyCSharpFix(src, fixtest);
+        }
+
+        [TestMethod]
+        public void TestPascalCaseFixForStringification()
+        {
+            string src = @"
+using Serilog;
+
+class TypeName
+{
+    public static void Test()
+    {
+        var foo = ""tester"";
+        Log.Verbose(""Hello {$tester}"", foo));
+    }
+}";
+            var expected = new DiagnosticResult
+            {
+                Id = "Serilog006",
+                Message = $"Property name '{"tester"}' should be pascal case",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 9, 28, 9)
+                }
+            };
+            VerifyCSharpDiagnostic(src, expected);
+
+            var fixtest = @"
+using Serilog;
+
+class TypeName
+{
+    public static void Test()
+    {
+        var foo = ""tester"";
+        Log.Verbose(""Hello {$Tester}"", foo));
+    }
+}";
+            VerifyCSharpFix(src, fixtest);
+        }
+
+        [TestMethod]
+        public void TestPascalCaseFixForEscapedString()
+        {
+            string src = @"
+using Serilog;
+
+class TypeName
+{
+    public static void Test()
+    {
+        var foo = ""tester"";
+        Log.Verbose(""Hello {{tester}} you will {foo}"", bar));
+    }
+}";
+            var expected = new DiagnosticResult
+            {
+                Id = "Serilog006",
+                Message = $"Property name '{"tester"}' should be pascal case",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 9, 28, 9)
+                }
+            };
+
+            // should ignore as the variable is escaped
+            VerifyCSharpFix(src, src);
+        }
+    }
+}

--- a/SerilogAnalyzer/SerilogAnalyzer.Test/SerilogAnalyzer.Test.csproj
+++ b/SerilogAnalyzer/SerilogAnalyzer.Test/SerilogAnalyzer.Test.csproj
@@ -119,6 +119,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConvertMessageTemplateAnalyzerTests.cs" />
+    <Compile Include="PascalCaseAnalyzerTests.cs" />
     <Compile Include="RefactoringTests.cs" />
     <Compile Include="Verifiers\CodeRefactoringVerifier.cs" />
     <Compile Include="Verifiers\CodeFixVerifier.cs" />

--- a/SerilogAnalyzer/SerilogAnalyzer.Test/Verifiers/DiagnosticVerifier.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer.Test/Verifiers/DiagnosticVerifier.cs
@@ -207,8 +207,7 @@ namespace TestHelper
                 if (actualLinePosition.Line + 1 != expected.Line)
                 {
                     Assert.IsTrue(false,
-                        string.Format("Expected diagnostic to be on line \"{0}\" was actually on line \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Line, actualLinePosition.Line + 1, FormatDiagnostics(analyzer, diagnostic)));
+                        $"Expected diagnostic to be on line \"{expected.Line}\" was actually on line \"{actualLinePosition.Line + 1}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, diagnostic)}\r\n");
                 }
             }
 

--- a/SerilogAnalyzer/SerilogAnalyzer/DiagnosticAnalyzer.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer/DiagnosticAnalyzer.cs
@@ -58,7 +58,13 @@ namespace SerilogAnalyzer
         private static readonly LocalizableString UniquePropertyNameDescription = new LocalizableResourceString(nameof(Resources.UniquePropertyNameAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
         private static DiagnosticDescriptor UniquePropertyNameRule = new DiagnosticDescriptor(UniquePropertyNameDiagnosticId, UniquePropertyNameTitle, UniquePropertyNameMessageFormat, "CodeQuality", DiagnosticSeverity.Error, isEnabledByDefault: true, description: UniquePropertyNameDescription);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(ExceptionRule, TemplateRule, PropertyBindingRule, ConstantMessageTemplateRule, UniquePropertyNameRule); } }
+        public const string PascalPropertyNameDiagnosticId = "Serilog006";
+        private static readonly LocalizableString PascalPropertyNameTitle = new LocalizableResourceString(nameof(Resources.PascalPropertyNameAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString PascalPropertyNameMessageFormat = new LocalizableResourceString(nameof(Resources.PascalPropertyNameAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString PascalPropertyNameDescription = new LocalizableResourceString(nameof(Resources.PascalPropertyNameAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+        private static DiagnosticDescriptor PascalPropertyNameRule = new DiagnosticDescriptor(PascalPropertyNameDiagnosticId, PascalPropertyNameTitle, PascalPropertyNameMessageFormat, "CodeQuality", DiagnosticSeverity.Warning, isEnabledByDefault: true, description: PascalPropertyNameDescription);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(ExceptionRule, TemplateRule, PropertyBindingRule, ConstantMessageTemplateRule, UniquePropertyNameRule, PascalPropertyNameRule); } }
 
         public override void Initialize(AnalysisContext context)
         {
@@ -175,6 +181,12 @@ namespace SerilogAnalyzer
                     if (!property.IsPositional && !usedNames.Add(property.PropertyName))
                     {
                         ReportDiagnostic(ref context, ref literalSpan, stringText, exactPositions, UniquePropertyNameRule, new MessageTemplateDiagnostic(property.StartIndex, property.Length, property.PropertyName));
+                    }
+
+                    var firstCharacter = property.PropertyName[0];
+                    if (!Char.IsDigit(firstCharacter) && !Char.IsUpper(firstCharacter))
+                    {
+                        ReportDiagnostic(ref context, ref literalSpan, stringText, exactPositions, PascalPropertyNameRule, new MessageTemplateDiagnostic(property.StartIndex, property.Length, property.PropertyName));
                     }
                 }
             }

--- a/SerilogAnalyzer/SerilogAnalyzer/Resources.Designer.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer/Resources.Designer.cs
@@ -116,6 +116,33 @@ namespace SerilogAnalyzer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Checks that all property names in a MessageTemplates are Pascal Case.
+        /// </summary>
+        internal static string PascalPropertyNameAnalyzerDescription {
+            get {
+                return ResourceManager.GetString("PascalPropertyNameAnalyzerDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Property name &apos;{0}&apos; should be pascal case.
+        /// </summary>
+        internal static string PascalPropertyNameAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("PascalPropertyNameAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pascal Property name verifier.
+        /// </summary>
+        internal static string PascalPropertyNameAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("PascalPropertyNameAnalyzerTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Checks wether properties and arguments match up.
         /// </summary>
         internal static string PropertyBindingAnalyzerDescription {

--- a/SerilogAnalyzer/SerilogAnalyzer/Resources.resx
+++ b/SerilogAnalyzer/SerilogAnalyzer/Resources.resx
@@ -176,5 +176,17 @@
   <data name="UniquePropertyNameAnalyzerTitle" xml:space="preserve">
     <value>Unique Property name verifier</value>
     <comment>The title of the diagnostic.</comment>
+  </data>  
+  <data name="PascalPropertyNameAnalyzerTitle" xml:space="preserve">
+    <value>Pascal Property name verifier</value>
+    <comment>The title of the diagnostic.</comment>
+  </data>
+  <data name="PascalPropertyNameAnalyzerMessageFormat" xml:space="preserve">
+    <value>Property name '{0}' should be pascal case</value>
+    <comment>The format-able message the diagnostic displays.</comment>
+  </data>
+  <data name="PascalPropertyNameAnalyzerDescription" xml:space="preserve">
+    <value>Checks that all property names in a MessageTemplates are Pascal Case</value>
+    <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
 </root>

--- a/SerilogAnalyzer/SerilogAnalyzer/SerilogAnalyzer.csproj
+++ b/SerilogAnalyzer/SerilogAnalyzer/SerilogAnalyzer.csproj
@@ -36,6 +36,7 @@
     <Compile Include="CodeFixProvider.cs" />
     <Compile Include="ConvertToMessageTemplateCodeRefactoringProvider.cs" />
     <Compile Include="Extensions.cs" />
+    <Compile Include="SerilogAnalyzerPascalCaseCodeFixProvider.cs" />
     <Compile Include="ShowConfigCodeRefactoringProvider.cs" />
     <Compile Include="ConfigurationModel.cs" />
     <Compile Include="DiagnosticAnalyzer.cs" />

--- a/SerilogAnalyzer/SerilogAnalyzer/SerilogAnalyzerPascalCaseCodeFixProvider.cs
+++ b/SerilogAnalyzer/SerilogAnalyzer/SerilogAnalyzerPascalCaseCodeFixProvider.cs
@@ -1,0 +1,91 @@
+// Copyright 2017 Serilog Analyzer Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SerilogAnalyzer
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SerilogAnalyzerCodeFixProvider)), Shared]
+    public class SerilogAnalyzerPascalCaseCodeFixProvider : CodeFixProvider
+    {
+        private const char stringificationPrefix = '$';
+        private const char destructuringPrefix = '@';
+        private const string title = "Pascal case the property";
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(SerilogAnalyzerAnalyzer.PascalPropertyNameDiagnosticId);
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            var declaration = root.FindNode(diagnosticSpan);
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: title,
+                    createChangedSolution: c => this.PascalCaseTheProperties(context.Document, (ArgumentSyntax)declaration, c),
+                    equivalenceKey: title),
+                diagnostic);
+        }
+
+        private async Task<Solution> PascalCaseTheProperties(Document document, ArgumentSyntax node, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var oldToken = node.GetFirstToken();
+
+            var text = oldToken.ValueText;
+            var matches = Regex.Matches(text, @"(?<!{){[@|$]?[a-z]\w+?}");
+            foreach (Match match in matches)
+            {
+                var matchValue = match.Value;
+                var chars = matchValue.ToCharArray();
+
+                if (chars[1] == destructuringPrefix || chars[1] == stringificationPrefix)
+                {
+                    chars[2] = Char.ToUpper(chars[2]);
+                    text = text.Replace(matchValue, new string(chars));
+                }
+                else
+                {
+                    chars[1] = Char.ToUpper(chars[1]);
+                    text = text.Replace(matchValue, new string(chars));
+                }
+            }
+
+            var newToken = SyntaxFactory.Literal(
+                SyntaxFactory.TriviaList(),
+                "\"" + text + "\"",
+                "\"" + text + "\"",
+                SyntaxFactory.TriviaList());
+            root = root.ReplaceToken(oldToken, newToken);
+
+            document = document.WithSyntaxRoot(root);
+            return document.Project.Solution;
+        }
+    }
+}


### PR DESCRIPTION
Ok, this works now, with both detecting and applying a code fix, but it isn't configurable, it will however only show as a warning rather than an error at the moment. 

I'll look into how we can do configuration when i get more time.